### PR TITLE
Add ApiEndpoint to NetworkException

### DIFF
--- a/src/Arbus.Network/ApiEndpoint.cs
+++ b/src/Arbus.Network/ApiEndpoint.cs
@@ -80,11 +80,11 @@ public abstract class ApiEndpoint
     public virtual Task HandleNotSuccessStatusCode(HttpResponseMessage responseMessage)
     {
         if (responseMessage.Content.Headers.ContentType?.MediaType == HttpContentType.Application.ProblemJson)
-            return HandleProblemDetailsResponse(responseMessage);
+            return HandleProblemDetailsResponse(responseMessage, this);
         return HandleAnyResponse(responseMessage);
     }
 
-    public static async Task HandleProblemDetailsResponse(HttpResponseMessage responseMessage)
+    public static async Task HandleProblemDetailsResponse(HttpResponseMessage responseMessage, ApiEndpoint endpoint)
     {
         var responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
@@ -92,13 +92,13 @@ public abstract class ApiEndpoint
             responseStream, GlobalJsonSerializerOptions.Options).ConfigureAwait(false)
             ?? throw new Exception("Failed to deserialize ProblemDetails.");
 
-        throw new NetworkException(responseMessage.StatusCode, problemDetails);
+        throw new NetworkException(responseMessage.StatusCode, problemDetails, endpoint);
     }
 
     public virtual async Task HandleAnyResponse(HttpResponseMessage responseMessage)
     {
         var responseString = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-        throw new NetworkException(responseMessage.StatusCode, responseString);
+        throw new NetworkException(responseMessage.StatusCode, responseString, this);
     }
 }
 

--- a/src/Arbus.Network/Exceptions/NetworkException.cs
+++ b/src/Arbus.Network/Exceptions/NetworkException.cs
@@ -7,16 +7,23 @@ public class NetworkException : Exception
     public HttpStatusCode? StatusCode { get; }
 
     public ProblemDetails? ProblemDetails { get; }
+    
+    public ApiEndpoint? Endpoint { get; }
 
-    public NetworkException(HttpStatusCode httpStatusCode, ProblemDetails problemDetails)
-        : this(httpStatusCode, problemDetails.Detail ?? problemDetails.Title ?? string.Empty)
+    public NetworkException(HttpStatusCode httpStatusCode, ProblemDetails problemDetails, ApiEndpoint endpoint)
+        : this(httpStatusCode, problemDetails.Detail ?? problemDetails.Title ?? string.Empty, endpoint)
     {
         ProblemDetails = problemDetails;
     }
 
-    public NetworkException(HttpStatusCode httpStatusCode, string message) : this(message)
+    public NetworkException(HttpStatusCode httpStatusCode, string message, ApiEndpoint endpoint) : this(message, endpoint)
     {
         StatusCode = httpStatusCode;
+    }
+
+    public NetworkException(string message, ApiEndpoint endpoint) : base(message)
+    {
+        Endpoint = endpoint;
     }
 
     public NetworkException(string message) : base(message)


### PR DESCRIPTION
Reopen PR because of git troubles.

Last problem that we disscussed: whether the Endpoint property should be nullable or not. I think yes, beacause we have NativeHttpClient that sends HttpRequestMessages and do not know anything about ApiEndpoint, but can throw NetworkException (e.g. HttpTimeoutException)

Related issue: https://github.com/ArbusBiz/Arbus.Network/issues/9