### PR TITLE
Feature. Add Extensions property for ProblemDetails class

### DIFF
--- a/src/Arbus.Network/ProblemDetails.cs
+++ b/src/Arbus.Network/ProblemDetails.cs
@@ -1,4 +1,6 @@
-﻿namespace Arbus.Network;
+﻿using System.Text.Json.Serialization;
+
+namespace Arbus.Network;
 
 /// <summary>
 /// A machine-readable format for specifying errors in HTTP API responses based on <a href="https://tools.ietf.org/html/rfc7807">specification</a>.
@@ -30,4 +32,18 @@ public record ProblemDetails
     ///     or may not yield further information if dereferenced.
     /// </summary>
     public string? Instance { get; set; }
+    
+    /// <summary>
+    /// Gets the <see cref="IDictionary{TKey, TValue}"/> for extension members.
+    /// <para>
+    /// Problem type definitions MAY extend the problem details object with additional members. Extension members appear in the same namespace as
+    /// other members of a problem type.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The round-tripping behavior for <see cref="Extensions"/> is determined by the implementation of the Input \ Output formatters.
+    /// In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
+    /// </remarks>
+    [JsonExtensionData]
+    public IDictionary<string, object?> Extensions { get; set; } = new Dictionary<string, object?>(StringComparer.Ordinal);
 }


### PR DESCRIPTION
Extensions property will allow to add additional data in problem details response like this:
```json
{
  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": {
    "dto": [
      "The dto field is required."
    ],
    "$.departmentId": [
      "The JSON value could not be converted to WebApplication1.ChildDto. Path: $.departmentId | LineNumber: 1 | BytePositionInLine: 55."
    ]
  },
  "traceId": "00-f71e1b29640ec8be900d0c5035a2a763-e2f2405507750efd-00"
}
```

Implementation I took from ASP NET Core